### PR TITLE
Support GHC 9.2

### DIFF
--- a/src/Data/HVect.hs
+++ b/src/Data/HVect.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts#-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}


### PR DESCRIPTION
This PR allows `hvect` to build with GHC 9.2.1.

Changes
- https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#undecidableinstances-no-longer-implies-flexiblecontexts-in-instance-declarations